### PR TITLE
Added DOCKER_BUILD condition check, to skip anything that starts a se…

### DIFF
--- a/tasks/router/ubuntu.yml
+++ b/tasks/router/ubuntu.yml
@@ -35,6 +35,7 @@
 
 - name: enable services at boot
   service: name=bind9 enabled=yes state=restarted daemon_reload=yes
+  when: DOCKER_BUILD is defined and DOCKER_BUILD != ""
 
 - name: Restart Network
   # Restart the network, sleep 3 seconds, return the
@@ -42,6 +43,7 @@
   # This is to work-around a glitch in Ansible where
   # it detects a successful network restart as a failure.
   command: perl -e 'my $exit_code = system("service networking restart"); sleep 3; $exit_code = $exit_code >> 8; exit($exit_code);'
+  when: DOCKER_BUILD is defined and DOCKER_BUILD != ""
 
 - name: Update resolvconf
   command: resolvconf -u


### PR DESCRIPTION
Added DOCKER_BUILD condition check, to skip anything that starts a service/interacts with systemd. In this case, this is related to bind9 and the network restart. It assumed that DOCKER_BUILD exists, and it's not empty -- ideally 'DOCKER_BUILD=yes'