### PR TITLE
adding DOCKER_BUILD check to skip configuring systemd services

### DIFF
--- a/tasks/router/main.yml
+++ b/tasks/router/main.yml
@@ -13,4 +13,5 @@
   tags: tokens
 
 - import_tasks: services.yml
+  when: DOCKER_BUILD is undefined or DOCKER_BUILD == 'no'
   tags: services


### PR DESCRIPTION
This should skip configuring systemd services when building with the DOCKER_BUILD flag set. Systemd services shouldn't be needed as long as the services are brought up by the docker container, i.e. entrypoint.sh or similar.