### PR TITLE
Add DOCKER_BUILD flag to skip systemd service tasks for smrt

### DIFF
--- a/tasks/smrt/main.yml
+++ b/tasks/smrt/main.yml
@@ -2,3 +2,4 @@
 - import_tasks: paths.yml
 - import_tasks: rules.yml
 - import_tasks: services.yml
+  when: DOCKER_BUILD is undefined or DOCKER_BUILD == 'no'


### PR DESCRIPTION
Like the cif-router tasks, we need to skip the systemd service tasks for cif-smrt.

With this change my Docker ansible build passes beyond the csirtgadgets.cif role.