### PR TITLE
Added exception for Docker around systemd and enabling services at boot

### DIFF
--- a/tasks/router/services.yml
+++ b/tasks/router/services.yml
@@ -5,9 +5,11 @@
   with_items:
     - cif-router.service
     - cif-httpd.service
+  when: DOCKER_BUILD is undefined or DOCKER_BUILD == "no"
 
 - name: enable services at boot
   systemd: name={{ item }} enabled=yes daemon_reload=yes state=started
   with_items:
     - cif-router.service
     - cif-httpd.service
+  when: DOCKER_BUILD is undefined or DOCKER_BUILD == "no"

--- a/tasks/smrt/services.yml
+++ b/tasks/smrt/services.yml
@@ -2,8 +2,10 @@
 
 - name: systemd services
   template: src=smrt/csirtg-smrt.service.j2 dest=/etc/systemd/system/csirtg-smrt.service owner=root group=root mode=0755
+  when: DOCKER_BUILD is undefined or DOCKER_BUILD == "no"
 
 - name: enable services at boot
   systemd: name={{ item }} enabled=yes daemon_reload=yes state=started
   with_items:
     - csirtg-smrt.service
+  when: DOCKER_BUILD is undefined or DOCKER_BUILD == "no"


### PR DESCRIPTION
This is exceptions for:

* router/services.yml
and
* smrt/services.yml

@dylanjacob ^ ping - I think this covers your pull request + the second half.