### PR TITLE
Use remote_src as file is on target already

### DIFF
--- a/tasks/router/centos.yml
+++ b/tasks/router/centos.yml
@@ -11,6 +11,7 @@
 
 - name: unarchive geoipupdate
   unarchive:
+    remote_src: yes
     src: /tmp/geoipupdate-2.2.2.tar.gz
     dest: /tmp/
 


### PR DESCRIPTION
The unarchive task fails if the playbook isn't run on the local machine. Using remote_src means it will unarchive the file on the target system.

`FAILED! => {"changed": false, "msg": "Could not find or access '/tmp/geoipupdate-2.2.2.tar.gz'"}`