### PR TITLE
made systemd service files not executable

### DIFF
--- a/tasks/router/services.yml
+++ b/tasks/router/services.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: systemd services
-  template: src=router/{{ item }}.j2 dest=/etc/systemd/system/{{ item }} owner=root group=root mode=0755
+  template: src=router/{{ item }}.j2 dest=/etc/systemd/system/{{ item }} owner=root group=root mode=0644
   with_items:
     - cif-router.service
     - cif-httpd.service

--- a/tasks/smrt/services.yml
+++ b/tasks/smrt/services.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: systemd services
-  template: src=smrt/csirtg-smrt.service.j2 dest=/etc/systemd/system/csirtg-smrt.service owner=root group=root mode=0755
+  template: src=smrt/csirtg-smrt.service.j2 dest=/etc/systemd/system/csirtg-smrt.service owner=root group=root mode=0644
 
 - name: enable services at boot
   systemd: name={{ item }} enabled=yes daemon_reload=yes state=started


### PR DESCRIPTION
Systemd service files for cif-httpd and cif-router were 755 and only need to be 644